### PR TITLE
[BUGFIX] Fix tag assigned in unit test for news

### DIFF
--- a/Tests/Unit/Domain/Model/NewsTest.php
+++ b/Tests/Unit/Domain/Model/NewsTest.php
@@ -239,7 +239,7 @@ class NewsTest extends UnitTestCase
 
         $tag = new Tag();
         $tag->setTitle('Tag');
-        $tags->attach($tags);
+        $tags->attach($tag);
         $this->newsDomainModelInstance->setTags($tags);
         $this->assertEquals($tags, $this->newsDomainModelInstance->getTags());
     }


### PR DESCRIPTION
We need to assigne the "tag" to the "tags" object storage. 
A small typo I guess...